### PR TITLE
Reorder the modifiers to comply with the Java Language Specification #1

### DIFF
--- a/jme3-android/src/main/java/com/jme3/app/AndroidHarness.java
+++ b/jme3-android/src/main/java/com/jme3/app/AndroidHarness.java
@@ -41,7 +41,7 @@ import java.util.logging.Logger;
  */
 public class AndroidHarness extends Activity implements TouchListener, DialogInterface.OnClickListener, SystemListener {
 
-    protected final static Logger logger = Logger.getLogger(AndroidHarness.class.getName());
+    protected static final  Logger logger = Logger.getLogger(AndroidHarness.class.getName());
     /**
      * The application class to start
      */


### PR DESCRIPTION
closes #1

Reorders the `final` and `static` modifiers to comply with the Java Language Specification.
- Before: `protected final static`
- After: `protected static final`