### PR TITLE
Fixed the issue of duplicating literal -Failed to open asset- 4 times…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,20 @@ buildscript {
     }
 }
 
+plugins {
+    id "org.sonarqube" version "6.0.1.5171"
+}
+
+sonarqube {
+    properties {
+        property "sonar.projectKey", "Project-Analysis"
+        property "sonar.projectName", "Project-Analysis"
+        property "sonar.host.url", "http://localhost:9000"
+        property "sonar.login", "sqp_54d0731713bb971f0065ad01c89bd3abcc77692a"
+    }
+}
+
+
 allprojects {
     repositories {
         mavenCentral()

--- a/jme3-android/src/main/java/com/jme3/asset/plugins/AndroidLocator.java
+++ b/jme3-android/src/main/java/com/jme3/asset/plugins/AndroidLocator.java
@@ -11,6 +11,7 @@ import java.util.logging.Logger;
 public class AndroidLocator implements AssetLocator {
 
     private static final Logger logger = Logger.getLogger(AndroidLocator.class.getName());
+    private static final String TAG = "Failed to open asset ";
 
     private String rootPath = "";
 
@@ -113,13 +114,13 @@ public class AndroidLocator implements AssetLocator {
                     try {
                         return androidResources.getAssets().open(assetPath);
                     } catch (IOException ex) {
-                        throw new AssetLoadException("Failed to open asset " + assetPath, ex);
+                        throw new AssetLoadException(TAG + assetPath, ex);
                     }
                 } else {
                     try {
                         return androidResources.openRawResource(resourceId);
                     } catch (Resources.NotFoundException ex) {
-                        throw new AssetLoadException("Failed to open asset " + assetPath, ex);
+                        throw new AssetLoadException(TAG + assetPath, ex);
                     }
                 }
             }
@@ -131,13 +132,13 @@ public class AndroidLocator implements AssetLocator {
                 try {
                     return androidResources.getAssets().openFd(assetPath);
                 } catch (IOException ex) {
-                    throw new AssetLoadException("Failed to open asset " + assetPath, ex);
+                    throw new AssetLoadException(TAG + assetPath, ex);
                 }
             } else {
                 try {
                     return androidResources.openRawResourceFd(resourceId);
                 } catch (Resources.NotFoundException ex) {
-                    throw new AssetLoadException("Failed to open asset " + assetPath, ex);
+                    throw new AssetLoadException(TAG + assetPath, ex);
                 }
             }
         }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,7 @@
+sonar.projectKey=Project-Analysis
+sonar.host.url=http://localhost:9000
+sonar.login=sqp_dfccdda4b3fd52defbdb37733327e86f82c5134b
+sonar.sources=.
+
+
+


### PR DESCRIPTION
Describe the pull request
This pull request addresses the 4 times repeating literal "Failed to open asset" in AndroidLocator class, where the literal "Failed to open asset" is repeated 4 times. There needs to be added a static final variable TAG, which works as a constant for this literal. This change removes the need to write the literal 4 times in code, improving code readability and maintainability.

Link to the the issue
https://github.com/RobertoNittolo/jmonkeyengineW25/issues/6
