### PR TITLE
Refactor exception handling in MjpegFileWriter.java: Use a dedicated exception instead of a generic one

### DIFF
--- a/jme3-android/src/main/java/com/jme3/app/state/ImageProcessingException.java
+++ b/jme3-android/src/main/java/com/jme3/app/state/ImageProcessingException.java
@@ -1,0 +1,11 @@
+package com.jme3.app.state;
+
+public class ImageProcessingException extends Exception {
+    public ImageProcessingException(String message) {
+        super(message);
+    }
+
+    public ImageProcessingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
I have addressed the SonarCloud issue where a generic Exception was being thrown in the addImage(byte[] imagedata) method within the MjpegFileWriter.java file. According to SonarCloud's recommendation, a dedicated exception should be defined and thrown to improve code clarity and maintainability.

**Changes Implemented:**

- Created a new custom exception class named ImageProcessingException.
- Updated the method addImage(byte[] imagedata) to throw ImageProcessingException instead of the generic Exception.
- Refactored the code to catch the original exception and rethrow it as ImageProcessingException with a meaningful error message.

**Files Modified**

1. src/main/java/com/jme3/app/state/MjpegFileWriter.java
2. src/main/java/com/jme3/app/state/ImageProcessingException.java (new class)