### PR TITLE
Refactored code to avoid duplication of distance method in 3 classes …

### DIFF
--- a/jme3-core/src/main/java/com/jme3/light/LightProbe.java
+++ b/jme3-core/src/main/java/com/jme3/light/LightProbe.java
@@ -39,6 +39,7 @@ import com.jme3.math.*;
 import com.jme3.renderer.Camera;
 import com.jme3.scene.Spatial;
 import com.jme3.texture.TextureCubeMap;
+import com.jme3.util.DistanceUtils;
 import com.jme3.util.TempVars;
 
 import java.io.IOException;
@@ -303,12 +304,7 @@ public class LightProbe extends Light implements Savable {
 
     @Override
     protected void computeLastDistance(Spatial owner) {
-        if (owner.getWorldBound() != null) {
-            BoundingVolume bv = owner.getWorldBound();
-            lastDistance = bv.distanceSquaredTo(position);
-        } else {
-            lastDistance = owner.getWorldTranslation().distanceSquared(position);
-        }
+        lastDistance = DistanceUtils.computeLastDistance(owner, position);
     }
 
     @Override

--- a/jme3-core/src/main/java/com/jme3/light/PointLight.java
+++ b/jme3-core/src/main/java/com/jme3/light/PointLight.java
@@ -43,6 +43,7 @@ import com.jme3.math.ColorRGBA;
 import com.jme3.math.Vector3f;
 import com.jme3.renderer.Camera;
 import com.jme3.scene.Spatial;
+import com.jme3.util.DistanceUtils;
 import com.jme3.util.TempVars;
 import java.io.IOException;
 
@@ -110,12 +111,7 @@ public class PointLight extends Light {
 
     @Override
     public void computeLastDistance(Spatial owner) {
-        if (owner.getWorldBound() != null) {
-            BoundingVolume bv = owner.getWorldBound();
-            lastDistance = bv.distanceSquaredTo(position);
-        } else {
-            lastDistance = owner.getWorldTranslation().distanceSquared(position);
-        }
+        lastDistance = DistanceUtils.computeLastDistance(owner, position);
     }
 
     /**

--- a/jme3-core/src/main/java/com/jme3/light/SpotLight.java
+++ b/jme3-core/src/main/java/com/jme3/light/SpotLight.java
@@ -42,6 +42,7 @@ import com.jme3.math.Plane;
 import com.jme3.math.Vector3f;
 import com.jme3.renderer.Camera;
 import com.jme3.scene.Spatial;
+import com.jme3.util.DistanceUtils;
 import com.jme3.util.TempVars;
 import java.io.IOException;
 
@@ -298,12 +299,7 @@ public class SpotLight extends Light {
     
     @Override
     protected void computeLastDistance(Spatial owner) {
-        if (owner.getWorldBound() != null) {
-            BoundingVolume bv = owner.getWorldBound();
-            lastDistance = bv.distanceSquaredTo(position);
-        } else {
-            lastDistance = owner.getWorldTranslation().distanceSquared(position);
-        }
+        lastDistance = DistanceUtils.computeLastDistance(owner, position);
     }
 
     @Override

--- a/jme3-core/src/main/java/com/jme3/util/DistanceUtils.java
+++ b/jme3-core/src/main/java/com/jme3/util/DistanceUtils.java
@@ -1,0 +1,16 @@
+package com.jme3.util;
+
+import com.jme3.bounding.BoundingVolume;
+import com.jme3.math.Vector3f;
+import com.jme3.scene.Spatial;
+
+public class DistanceUtils {
+    public static float computeLastDistance(Spatial owner, Vector3f position) {
+        if (owner.getWorldBound() != null) {
+            BoundingVolume bv = owner.getWorldBound();
+            return bv.distanceSquaredTo(position);
+        } else {
+            return owner.getWorldTranslation().distanceSquared(position);
+        }
+    }
+}


### PR DESCRIPTION
This PR refactors the duplicated method computeLastDistance in three java classes LightProbe.java, PointLight.java and SpotLight.java. A new java class DistanceUtils is added with same logic as computeLastDistance to be used in all three classes without having to duplicate logic in all of them.

Linked Issue
#21 