### PR TITLE
Refactor: Add a helper method to remove duplication in adjoint and inverse methods

### DIFF
--- a/jme3-core/src/main/java/com/jme3/math/Matrix4f.java
+++ b/jme3-core/src/main/java/com/jme3/math/Matrix4f.java
@@ -1485,6 +1485,27 @@ public final class Matrix4f implements Savable, Cloneable, java.io.Serializable 
         return invert(null);
     }
 
+
+    private void storeMatrix(float[] fA, float[] fB, Matrix4f store) {
+        store.m00 = +m11 * fB[5] - m12 * fB[4] + m13 * fB[3];
+        store.m10 = -m10 * fB[5] + m12 * fB[2] - m13 * fB[1];
+        store.m20 = +m10 * fB[4] - m11 * fB[2] + m13 * fB[0];
+        store.m30 = -m10 * fB[3] + m11 * fB[1] - m12 * fB[0];
+        store.m01 = -m01 * fB[5] + m02 * fB[4] - m03 * fB[3];
+        store.m11 = +m00 * fB[5] - m02 * fB[2] + m03 * fB[1];
+        store.m21 = -m00 * fB[4] + m01 * fB[2] - m03 * fB[0];
+        store.m31 = +m00 * fB[3] - m01 * fB[1] + m02 * fB[0];
+        store.m02 = +m31 * fA[5] - m32 * fA[4] + m33 * fA[3];
+        store.m12 = -m30 * fA[5] + m32 * fA[2] - m33 * fA[1];
+        store.m22 = +m30 * fA[4] - m31 * fA[2] + m33 * fA[0];
+        store.m32 = -m30 * fA[3] + m31 * fA[1] - m32 * fA[0];
+        store.m03 = -m21 * fA[5] + m22 * fA[4] - m23 * fA[3];
+        store.m13 = +m20 * fA[5] - m22 * fA[2] + m23 * fA[1];
+        store.m23 = -m20 * fA[4] + m21 * fA[2] - m23 * fA[0];
+        store.m33 = +m20 * fA[3] - m21 * fA[1] + m22 * fA[0];
+    }
+
+
     /**
      * Generate the inverse.
      *
@@ -1516,22 +1537,10 @@ public final class Matrix4f implements Savable, Cloneable, java.io.Serializable 
             throw new ArithmeticException("This matrix cannot be inverted");
         }
 
-        store.m00 = +m11 * fB5 - m12 * fB4 + m13 * fB3;
-        store.m10 = -m10 * fB5 + m12 * fB2 - m13 * fB1;
-        store.m20 = +m10 * fB4 - m11 * fB2 + m13 * fB0;
-        store.m30 = -m10 * fB3 + m11 * fB1 - m12 * fB0;
-        store.m01 = -m01 * fB5 + m02 * fB4 - m03 * fB3;
-        store.m11 = +m00 * fB5 - m02 * fB2 + m03 * fB1;
-        store.m21 = -m00 * fB4 + m01 * fB2 - m03 * fB0;
-        store.m31 = +m00 * fB3 - m01 * fB1 + m02 * fB0;
-        store.m02 = +m31 * fA5 - m32 * fA4 + m33 * fA3;
-        store.m12 = -m30 * fA5 + m32 * fA2 - m33 * fA1;
-        store.m22 = +m30 * fA4 - m31 * fA2 + m33 * fA0;
-        store.m32 = -m30 * fA3 + m31 * fA1 - m32 * fA0;
-        store.m03 = -m21 * fA5 + m22 * fA4 - m23 * fA3;
-        store.m13 = +m20 * fA5 - m22 * fA2 + m23 * fA1;
-        store.m23 = -m20 * fA4 + m21 * fA2 - m23 * fA0;
-        store.m33 = +m20 * fA3 - m21 * fA1 + m22 * fA0;
+        float[] fA = {fA0, fA1, fA2, fA3, fA4, fA5};
+        float[] fB = {fB0, fB1, fB2, fB3, fB4, fB5};
+
+        storeMatrix(fA, fB, store);
 
         float fInvDet = 1.0f / fDet;
         store.multLocal(fInvDet);
@@ -1674,22 +1683,10 @@ public final class Matrix4f implements Savable, Cloneable, java.io.Serializable 
         float fB4 = m21 * m33 - m23 * m31;
         float fB5 = m22 * m33 - m23 * m32;
 
-        store.m00 = +m11 * fB5 - m12 * fB4 + m13 * fB3;
-        store.m10 = -m10 * fB5 + m12 * fB2 - m13 * fB1;
-        store.m20 = +m10 * fB4 - m11 * fB2 + m13 * fB0;
-        store.m30 = -m10 * fB3 + m11 * fB1 - m12 * fB0;
-        store.m01 = -m01 * fB5 + m02 * fB4 - m03 * fB3;
-        store.m11 = +m00 * fB5 - m02 * fB2 + m03 * fB1;
-        store.m21 = -m00 * fB4 + m01 * fB2 - m03 * fB0;
-        store.m31 = +m00 * fB3 - m01 * fB1 + m02 * fB0;
-        store.m02 = +m31 * fA5 - m32 * fA4 + m33 * fA3;
-        store.m12 = -m30 * fA5 + m32 * fA2 - m33 * fA1;
-        store.m22 = +m30 * fA4 - m31 * fA2 + m33 * fA0;
-        store.m32 = -m30 * fA3 + m31 * fA1 - m32 * fA0;
-        store.m03 = -m21 * fA5 + m22 * fA4 - m23 * fA3;
-        store.m13 = +m20 * fA5 - m22 * fA2 + m23 * fA1;
-        store.m23 = -m20 * fA4 + m21 * fA2 - m23 * fA0;
-        store.m33 = +m20 * fA3 - m21 * fA1 + m22 * fA0;
+        float[] fA = {fA0, fA1, fA2, fA3, fA4, fA5};
+        float[] fB = {fB0, fB1, fB2, fB3, fB4, fB5};
+
+        storeMatrix(fA, fB, store);
 
         return store;
     }


### PR DESCRIPTION
# Description
The storing logic for the adjoint and inverse methods was identical. 
![image](https://github.com/user-attachments/assets/4144e8d8-1d68-4fde-a855-3450b4a703dc)


To remove the code duplication, a helper method called storeMatrix was created.

# Changes
- Add storeMatrix method
- Remove code duplication in adjoint and inverse methods

# Linked Issue
closes #23 