### PR TITLE
Prevent XXE attack in SceneMaterialLoader.java

### DIFF
--- a/jme3-plugins/src/ogre/java/com/jme3/scene/plugins/ogre/SceneMaterialLoader.java
+++ b/jme3-plugins/src/ogre/java/com/jme3/scene/plugins/ogre/SceneMaterialLoader.java
@@ -125,10 +125,16 @@ class SceneMaterialLoader extends DefaultHandler {
             this.folderName = folderName;
             
             reset();
-            
+
             SAXParserFactory factory = SAXParserFactory.newInstance();
-            factory.setNamespaceAware(true);  
-            XMLReader xr = factory.newSAXParser().getXMLReader();  
+            factory.setNamespaceAware(true);
+
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+
+            XMLReader xr = factory.newSAXParser().getXMLReader();
 
             xr.setContentHandler(this);
             xr.setErrorHandler(this);


### PR DESCRIPTION
# Description
Disable access to external entities in XML parsing.
XML parsers should not be vulnerable to XXE attacks

# Changes
- disabled doctype
- disabled external entities declarations 
- disabled loading of external dtd


# Linked Issue
closes #29

# References 
Article talking about XXE attacks 
https://www.sonarsource.com/blog/secure-xml-processor/