### PR TITLE
Secured XMLExporter against XXE attacks.

### DIFF
--- a/jme3-plugins/src/xml/java/com/jme3/export/xml/XMLExporter.java
+++ b/jme3-plugins/src/xml/java/com/jme3/export/xml/XMLExporter.java
@@ -79,7 +79,16 @@ public class XMLExporter implements JmeExporter {
     public void save(Savable object, OutputStream outputStream) throws IOException {
         Document document = null;
         try {
-            document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            // XXE Protection for Document Builder
+            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            dbf.setXIncludeAware(false);
+            dbf.setExpandEntityReferences(false);
+
+            document = dbf.newDocumentBuilder().newDocument();
         } catch (ParserConfigurationException ex) {
             throw new IOException(ex);
         }
@@ -95,6 +104,10 @@ public class XMLExporter implements JmeExporter {
 
         try {
             TransformerFactory tfFactory = TransformerFactory.newInstance();
+            // XXE Protection for Transformer
+            tfFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            tfFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            tfFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
             tfFactory.setAttribute("indent-number", indentSpaces);
 
             Transformer transformer = tfFactory.newTransformer();

--- a/jme3-plugins/src/xml/java/com/jme3/export/xml/XMLExporter.java
+++ b/jme3-plugins/src/xml/java/com/jme3/export/xml/XMLExporter.java
@@ -79,7 +79,13 @@ public class XMLExporter implements JmeExporter {
     public void save(Savable object, OutputStream outputStream) throws IOException {
         Document document = null;
         try {
-            document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            // XXE Protection for Document Builder
+            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            dbf.setXIncludeAware(false);
+            dbf.setExpandEntityReferences(false);
+
+            document = dbf.newDocumentBuilder().newDocument();
         } catch (ParserConfigurationException ex) {
             throw new IOException(ex);
         }

--- a/jme3-plugins/src/xml/java/com/jme3/export/xml/XMLExporter.java
+++ b/jme3-plugins/src/xml/java/com/jme3/export/xml/XMLExporter.java
@@ -79,16 +79,7 @@ public class XMLExporter implements JmeExporter {
     public void save(Savable object, OutputStream outputStream) throws IOException {
         Document document = null;
         try {
-            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-            // XXE Protection for Document Builder
-            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-            dbf.setXIncludeAware(false);
-            dbf.setExpandEntityReferences(false);
-
-            document = dbf.newDocumentBuilder().newDocument();
+            document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
         } catch (ParserConfigurationException ex) {
             throw new IOException(ex);
         }
@@ -104,10 +95,6 @@ public class XMLExporter implements JmeExporter {
 
         try {
             TransformerFactory tfFactory = TransformerFactory.newInstance();
-            // XXE Protection for Transformer
-            tfFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            tfFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            tfFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
             tfFactory.setAttribute("indent-number", indentSpaces);
 
             Transformer transformer = tfFactory.newTransformer();


### PR DESCRIPTION
# Description
Disable access to external entities in XML parsing.
XML parsers should not be vulnerable to XXE attacks

# Changes
- disabled doctype
- disabled external entities declarations 
- disabled loading of external dtd


# Linked Issue
closes #31 

# References 
Article talking about XXE attacks 
https://www.sonarsource.com/blog/secure-xml-processor/