### PR TITLE
Software vulnerability - Path traversal in ExtractNativeLibraries.java

### DIFF
--- a/jme3-desktop/src/main/java/com/jme3/system/ExtractNativeLibraries.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/ExtractNativeLibraries.java
@@ -65,8 +65,24 @@ public class ExtractNativeLibraries {
             System.err.println("You can also use ExtractNativeLibraries getjarexcludes to get a list of excludes for the jar files that contain binaries.");
             System.exit(1);
         }
-        String path = args[1].replace('/', File.separatorChar);
-        File folder = new File(path);
+        String inputPath = args[1];
+        File folder;
+        File baseDir;
+
+        try {
+            folder = new File(inputPath).getAbsoluteFile().toPath().normalize().toFile();
+            baseDir = new File(".").getCanonicalFile();
+
+            if (!folder.getCanonicalPath().startsWith(baseDir.getCanonicalPath())) {
+                System.err.println("Invalid path: potential path traversal attempt detected.");
+                System.exit(2);
+            }
+        } catch (IOException e) {
+            System.err.println("Error resolving paths: " + e.getMessage());
+            System.exit(2);
+            return; // added for clarity, although System.exit already exits
+        }
+
         try {
             if ("Windows32".equals(args[0])) {
                 NativeLibraryLoader.extractNativeLibraries(Platform.Windows32, folder);


### PR DESCRIPTION
Description:

Issue:
The issue was a Path Traversal vulnerability caused by using unsanitized user input (args[1]) to construct a file path. An attacker could exploit this by passing input like ../../outside/folder, allowing access to unauthorized directories. This bypasses intended directory restrictions and could lead to data exposure or modification.

Solution:
The fix normalizes and canonicalizes the user-supplied path to eliminate any ../ or symbolic link traversal. It then checks that the resolved path stays within a trusted base directory (e.g., project root). If the check fails, it logs an error and safely exits to prevent unauthorized file access.

Changes:

- Normalized and canonicalized the input path to remove ../ and resolve symlinks.
- Added a check to ensure the path stays within a trusted base directory.
- Exits the program if a potential path traversal attempt is detected.

Linked Issue:
closes #38 
