### PR TITLE
Fix security vulnerability: replace printStackTrace with Logger in IrradianceSphericalHarmonicsGenerator

### DIFF
--- a/jme3-core/src/main/java/com/jme3/environment/generation/IrradianceSphericalHarmonicsGenerator.java
+++ b/jme3-core/src/main/java/com/jme3/environment/generation/IrradianceSphericalHarmonicsGenerator.java
@@ -37,6 +37,8 @@ import com.jme3.light.LightProbe;
 import com.jme3.math.Vector3f;
 import com.jme3.texture.TextureCubeMap;
 import java.util.concurrent.Callable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 
 /**
@@ -52,6 +54,8 @@ public class IrradianceSphericalHarmonicsGenerator extends RunnableWithProgress 
     private TextureCubeMap sourceMap;
     private LightProbe store;
     private final Application app;
+    private static final Logger LOGGER = Logger.getLogger(IrradianceSphericalHarmonicsGenerator.class.getName());
+
 
     /**
      * Creates an Irradiance map generator. The app is needed to enqueue the
@@ -96,7 +100,7 @@ public class IrradianceSphericalHarmonicsGenerator extends RunnableWithProgress 
             store.setShCoeffs(shCoefficients);
 
         } catch (Exception e) {
-            e.printStackTrace();
+            LOGGER.log(Level.SEVERE, "Error while generating spherical harmonics", e);
         }
         app.enqueue(new Callable<Void>() {
 


### PR DESCRIPTION
**Summary**
This pull request removes the use of printStackTrace() in IrradianceSphericalHarmonicsGenerator and replaces it with a Logger to address a security vulnerability flagged by SonarQube.

**Changes**
Removed e.printStackTrace() calls.
Added java.util.logging.Logger to log exceptions at SEVERE level.
Ensured the overall functionality remains unchanged.

**Reasoning**
printStackTrace() can reveal sensitive information in production logs.
Proper logging helps maintain security and compliance standards.