### PR TITLE
Security Fix: Mitigate XXE Vulnerability in SkeletonLoader.java

### DIFF
--- a/jme3-plugins/src/ogre/java/com/jme3/scene/plugins/ogre/SkeletonLoader.java
+++ b/jme3-plugins/src/ogre/java/com/jme3/scene/plugins/ogre/SkeletonLoader.java
@@ -263,7 +263,11 @@ public class SkeletonLoader extends DefaultHandler implements AssetLoader {
             // checking with JmeSystem.
             SAXParserFactory factory = SAXParserFactory.newInstance();
             factory.setNamespaceAware(true);
-            XMLReader xr = factory.newSAXParser().getXMLReader();  
+            XMLReader xr = factory.newSAXParser().getXMLReader();
+
+            xr.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            xr.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            xr.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
                          
             xr.setContentHandler(this);
             xr.setErrorHandler(this);


### PR DESCRIPTION
## Description  
This PR addresses the XXE vulnerability identified by SonarQube (`java:S2755`) in the `SkeletonLoader` class.  

## Changes  
- Disabled DTD processing and external entities in the SAX parser.  
- Set features `disallow-doctype-decl`, `external-general-entities`, and `external-parameter-entities` to block unsafe XML parsing.  

## References  
- Closes #42 